### PR TITLE
Add CI jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,55 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+template: |
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+  ---
+
+  ### Release Guide
+
+  1. Bump version in `pyproject.toml`
+  2. Update `CHANGELOG.md` with notes from release draft and header with version and release date
+  3. Process links in `CHANGELOG.md` and check release date by calling `tools/process_changelog.py`
+  4. Open a PR with the above changes and merge it
+  5. Release the version by editing the draft
+
+categories:
+  - title: Added
+    labels:
+      - added
+  - title: Changed
+    labels:
+      - changed
+  - title: Deprecated
+    labels:
+      - deprecated
+  - title: Removed
+    labels:
+      - removed
+  - title: Fixed
+    labels:
+      - fixed
+
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  major:
+    labels:
+      - major
+  minor:
+    labels:
+      - minor
+  patch:
+    labels:
+      - patch
+  default: patch
+
+include-labels:
+  - "added"
+  - "changed"
+  - "deprecated"
+  - "removed"
+  - "fixed"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,104 @@
+name: Docs
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Set up CUDA toolkit
+        uses: Jimver/cuda-toolkit@master
+        with:
+          cuda: "12.1.0"
+          method: "network"
+          sub-packages: '["toolkit"]'
+
+      - name: Install torch with CUDA support
+        run: python -m pip install torch --index-url https://download.pytorch.org/whl/cu121
+
+      - name: Install torchhull
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Build docs
+        run: nox -s docs
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Docs HTML
+          path: build/docs/html
+
+  publish:
+    name: Upload release to GitHub Pages
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    needs:
+      - build
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Docs HTML
+          path: build/docs/html
+
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build/docs/html
+          clean: true
+          single-commit: true
+
+  check_docs:
+    if: always()
+
+    needs:
+      - build
+      - publish
+
+    name: "Check Docs"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: publish
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,52 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.9", "3.10", "3.11", "3.12"]
+
+    name: "Python ${{ matrix.python }}"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: "pip"
+
+      - name: Install torchhull
+        run: python -m pip install --editable ".[dev]"
+
+      - name: Run linters
+        run: nox -s lint
+
+  check_lint:
+    if: always()
+
+    needs:
+      - lint
+
+    name: "Check Lint"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,92 @@
+name: PyPi
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dist:
+    name: Distribution build
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  publish-test:
+    name: Upload release to TestPyPI
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    needs:
+      - dist
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/torchhull
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    needs:
+      - publish-test
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/torchhull
+
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  check_pypi:
+    if: always()
+
+    needs:
+      - dist
+      - publish-test
+      - publish
+
+    name: "Check PyPI"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: publish-test, publish
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  Update:
+    permissions:
+      contents: write
+      pull-requests: read
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
After the initial release of the code, we can now check it automatically. Set up respective CI jobs for this purpose.