### PR TITLE
Move numpy to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{ name = "Patrick Stotko", email = "stotko@cs.uni-bonn.de" }]
 description = "A fast Visual Hull implementation"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["torch", "numpy", "charonload"]
+dependencies = ["torch", "charonload"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",
@@ -59,6 +59,7 @@ dev = [
 
     # Tests
     "moderngl",
+    "numpy",
     "pillow",
     "pytest",
     "pytest-benchmark",


### PR DESCRIPTION
numpy is not directly used inside torchhull, so specifying it as a mandatory dependency is not required. Instead, it is used in the data generation script and should thus be part of the dev dependencies. Move numpy there to clean up the dependency relations.