### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04"]  # "windows-2022" # Disabled until solution/workaround for NVTX is present
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        os: ["ubuntu-22.04"] # "windows-2022" # Disabled until solution/workaround for NVTX is present
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     name: "${{ matrix.os }} / Python ${{ matrix.python }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
 
       - name: Set up CUDA toolkit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     name: "Python ${{ matrix.python }}"
     runs-on: ubuntu-22.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Image Recognition",
     "Topic :: Scientific/Engineering :: Visualization",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
Python 3.13 has been released on 2024-10-07 and torch has also started to support it recently. Add this support on our side as well.