### PR TITLE
Fix recent ruff linter warnings

### DIFF
--- a/src/torchhull/__init__.py
+++ b/src/torchhull/__init__.py
@@ -21,7 +21,7 @@ import sys
 required_version = (3, 9)
 
 if sys.version_info[:2] < required_version:  # pragma: no cover
-    msg = "%s requires Python %d.%d+" % (__package__, *required_version)
+    msg = "%s requires Python %d.%d+" % (__package__, *required_version)  # noqa: UP031
     raise RuntimeError(msg)
 
 del required_version


### PR DESCRIPTION
A lot of time has passed since the last linter checks and ruff has received several larger updates containing new and updated rules. Address the warnings raised by these additional rules.