### PR TITLE
Support non-binary masks from matting approaches

### DIFF
--- a/tests/test_visual_hull.py
+++ b/tests/test_visual_hull.py
@@ -37,7 +37,7 @@ def list_levels() -> list[int]:
 @pytest.mark.parametrize("masks_partial", [True, False])
 @pytest.mark.parametrize("unique_verts", [True, False])
 @pytest.mark.parametrize(
-    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float32, torch.float64]
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
 )
 @pytest.mark.parametrize("dtype_transforms", [torch.float32, torch.float64])
 def test_visual_hull_empty_masks(
@@ -78,7 +78,7 @@ def test_visual_hull_empty_masks(
 @pytest.mark.parametrize("masks_partial", [True, False])
 @pytest.mark.parametrize("unique_verts", [True, False])
 @pytest.mark.parametrize(
-    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float32, torch.float64]
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
 )
 @pytest.mark.parametrize("dtype_transforms", [torch.float32, torch.float64])
 def test_visual_hull_full_masks(
@@ -119,7 +119,7 @@ def test_visual_hull_full_masks(
 @pytest.mark.parametrize("masks_partial", [True, False])
 @pytest.mark.parametrize("unique_verts", [True, False])
 @pytest.mark.parametrize(
-    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float32, torch.float64]
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
 )
 @pytest.mark.parametrize("dtype_transforms", [torch.float32, torch.float64])
 def test_visual_hull(
@@ -162,7 +162,7 @@ def test_visual_hull(
 @pytest.mark.parametrize("masks_partial", [True, False])
 @pytest.mark.parametrize("unique_verts", [True, False])
 @pytest.mark.parametrize(
-    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float32, torch.float64]
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
 )
 @pytest.mark.parametrize("dtype_transforms", [torch.float32, torch.float64])
 def test_visual_hull_with_candidate_voxels(


### PR DESCRIPTION
To detect candidate voxels, the mask values covered by the voxel's footprint after projection are efficiently collected by evaluating integral masks. Currently, the integral images assume binary masks and are `int32_t` tensors. Support non-binary masks by moving to `float` integral masks and accounting for potential numerical inaccuracies. On the other hand, this also enables a more fine-grained inside/outside check that can reduce the number of empty candidates.