### PR TITLE
Add standard and optimized Gaussian blur for masks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ torchhull is an extremely fast Torch C++/CUDA implementation for computing visua
 - ⚡ Up to real-time capable speed depending on chosen resolution
 - 🗜️ Memory-efficient computation by constructing sparse voxel octrees
 - 🌊 Watertight mesh generation via Marching Cubes
+- 🎈 Smooth surfaces with sparse Gaussian blur preprocessing tailored for mask images
 - 🛠️ Support for partially visible objects, i.e. clipped mask images, and fully observed objects
 
 
@@ -76,6 +77,13 @@ The visual hull is then evaluated inside a cube with bottom-front-left corner `c
 
 ```python
 import torchhull
+
+# Optional
+masks = torchhull.gaussian_blur(masks, # [B, H, W, 1]
+                                kernel_size,
+                                sigma,
+                                sparse=True,
+                               )
 
 verts, faces = torchhull.visual_hull(masks,  # [B, H, W, 1]
                                      transforms,  # [B, 4, 4]

--- a/benchmarks/test_bench_gaussian_blur.py
+++ b/benchmarks/test_bench_gaussian_blur.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import enum
+import functools
+import pathlib
+import sys
+
+import pytest
+import torch
+
+import torchhull
+
+DATA_DIR = pathlib.Path(__file__).parents[1] / "data"
+sys.path.append(str(DATA_DIR))
+from generate_dataset import generate_dataset  # noqa: E402
+
+generate_dataset = functools.cache(generate_dataset)
+
+
+DEVICE = torch.device("cuda")
+
+
+class ImplementationType(enum.Enum):
+    DENSE = enum.auto()
+    SPARSE = enum.auto()
+
+    def __str__(self) -> str:
+        return f"{self.name}"
+
+
+@pytest.mark.parametrize("number_cameras", [10, 30, 50])
+@pytest.mark.parametrize("kernel_size", [3, 5, 7, 9, 11])
+@pytest.mark.parametrize("implementation_type", [ImplementationType.DENSE, ImplementationType.SPARSE])
+def test_gaussian_blur(
+    benchmark,  # noqa: ANN001
+    number_cameras: int,
+    kernel_size: int,
+    implementation_type: ImplementationType,
+) -> None:
+    torch.cuda.empty_cache()
+
+    data_dir = pathlib.Path(__file__).parents[1] / "data"
+    file = "Armadillo.ply"
+
+    _, _, masks = generate_dataset(
+        mesh_file=data_dir / file,
+        number_cameras=number_cameras,
+        device=DEVICE,
+    )
+
+    masks = masks.to(dtype=torch.float32, device=DEVICE)
+    sigma = 1.0
+    sparse = implementation_type == ImplementationType.SPARSE
+
+    # Warmup
+    torchhull.gaussian_blur(
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=sparse,
+    )
+
+    benchmark(
+        torchhull.gaussian_blur,
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=sparse,
+    )

--- a/src/torchhull/_C/CMakeLists.txt
+++ b/src/torchhull/_C/CMakeLists.txt
@@ -66,13 +66,16 @@ if(charonload_FOUND)
     charonload_add_torch_library(torchhull_cpp STATIC)
     add_library(torchhull::torchhull_cpp ALIAS torchhull_cpp)
 
-    target_sources(torchhull_cpp PRIVATE src/io.cpp
+    target_sources(torchhull_cpp PRIVATE src/gaussian_blur_cuda.cu
+                                         src/gaussian_blur.cpp
+                                         src/io.cpp
                                          src/marching_cubes_cuda.cu
                                          src/marching_cubes.cpp
                                          src/visual_hull_cuda.cu
                                          src/visual_hull.cpp)
 
     target_include_directories(torchhull_cpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+    target_compile_definitions(torchhull_cpp PRIVATE "__CUDA_NO_HALF_OPERATORS__")
     target_compile_features(torchhull_cpp PUBLIC cxx_std_17)
     target_compile_options(torchhull_cpp PRIVATE ${HOST_DEVICE_FLAGS})
     target_link_libraries(torchhull_cpp PRIVATE glm::glm stdgpu::stdgpu)

--- a/src/torchhull/_C/include/torchhull/gaussian_blur.h
+++ b/src/torchhull/_C/include/torchhull/gaussian_blur.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <optional>
+
+#include <torch/types.h>
+
+namespace torchhull
+{
+
+torch::Tensor
+gaussian_blur(const torch::Tensor& images,
+              const int kernel_size,
+              const float sigma,
+              const bool sparse = true,
+              const std::optional<torch::ScalarType> dtype = std::nullopt);
+
+} // namespace torchhull

--- a/src/torchhull/_C/include/torchhull/math.h
+++ b/src/torchhull/_C/include/torchhull/math.h
@@ -1,11 +1,20 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 #include <c10/macros/Macros.h>
 
 namespace torchhull
 {
+
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>, void>>
+inline C10_HOST_DEVICE T
+mod(const T x, const T y)
+{
+    T rem = x % y;
+    return (rem >= 0) ? rem : rem + y;
+}
 
 inline C10_HOST_DEVICE float
 lerp(const float v0, const float v1, const float t)

--- a/src/torchhull/_C/include/torchhull/preprocessor.h
+++ b/src/torchhull/_C/include/torchhull/preprocessor.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define EMPTY()
+#define DEFER(...) __VA_ARGS__ EMPTY()
+#define EVAL(...) __VA_ARGS__

--- a/src/torchhull/_C/python/bindings.cpp
+++ b/src/torchhull/_C/python/bindings.cpp
@@ -1,5 +1,6 @@
 #include <torch/python.h>
 
+#include <torchhull/gaussian_blur.h>
 #include <torchhull/io.h>
 #include <torchhull/marching_cubes.h>
 #include <torchhull/visual_hull.h>
@@ -201,6 +202,43 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         -------
         verts: The vertex tensor of the extracted scene. \|V\| x 3. float32.
         faces: The face tensor of the extracted scene. \|F\| x 3. int64.
+    )");
+
+    m.def("gaussian_blur",
+          &torchhull::gaussian_blur,
+          "images"_a,
+          "kernel_size"_a,
+          "sigma"_a,
+          "sparse"_a = true,
+          "dtype"_a = py::none(),
+          R"(
+        Blurs the given images with a Gaussian kernel.
+
+        Note
+        ----
+            Not differentiable.
+
+        Note
+        ----
+            CUDA backend only.
+
+        Parameters
+        ----------
+        images
+            The image tensor. B x H x W x C.
+        kernel_size
+            The size of the kernel. Must be an odd number.
+        sigma
+            The standard deviation of the kernel.
+        sparse
+            Whether to use the sparse implementation optimized for masks or the standard dense version.
+        dtype
+            Optional dtype of the returned tensor. If set to `None`, the dtype of the input images is selected.
+            Must be a floating-point type.
+
+        Returns
+        -------
+        Blurred images. B x H x W x C.
     )");
 
     m.def("store_curve_network",

--- a/src/torchhull/_C/src/gaussian_blur.cpp
+++ b/src/torchhull/_C/src/gaussian_blur.cpp
@@ -1,0 +1,30 @@
+#include <torchhull/gaussian_blur.h>
+
+#include <c10/util/Exception.h>
+
+namespace torchhull
+{
+
+torch::Tensor
+gaussian_blur_cuda(const torch::Tensor& images,
+                   const int kernel_size,
+                   const float sigma,
+                   const bool sparse,
+                   const std::optional<torch::ScalarType> dtype);
+
+torch::Tensor
+gaussian_blur(const torch::Tensor& images,
+              const int kernel_size,
+              const float sigma,
+              const bool sparse,
+              const std::optional<torch::ScalarType> dtype)
+{
+    if (images.is_cuda())
+    {
+        return gaussian_blur_cuda(images, kernel_size, sigma, sparse, dtype);
+    }
+
+    TORCH_CHECK(false, "No backend implementation available for device \"" + images.device().str() + "\".");
+}
+
+} // namespace torchhull

--- a/src/torchhull/_C/src/gaussian_blur_cuda.cu
+++ b/src/torchhull/_C/src/gaussian_blur_cuda.cu
@@ -1,0 +1,521 @@
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/ApplyGridUtils.cuh>
+#include <ATen/cuda/ThrustAllocator.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Exception.h>
+#include <cub/device/device_select.cuh>
+#include <glm/vec2.hpp>
+#include <thrust/execution_policy.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/sort.h>
+#include <torch/nn/functional.h>
+#include <torch/types.h>
+
+#include <torchhull/image_utils.h>
+#include <torchhull/preprocessor.h>
+
+namespace torchhull
+{
+
+template <typename KernelT>
+__global__ void
+gaussian_kernel(torch::PackedTensorAccessor64<KernelT, 2, torch::RestrictPtrTraits> kernel, const float sigma)
+{
+    const auto kernel_size = kernel.size(0);
+    const auto N = kernel_size * kernel_size;
+
+    const auto kernel_half_size = kernel_size / 2;
+
+    auto id = static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) + static_cast<int64_t>(threadIdx.x);
+    auto num_threads = static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x);
+    for (auto tid = id; tid < N; tid += num_threads)
+    {
+        auto p = glm::i64vec2{ tid % kernel_size, tid / kernel_size }; // unravel_index
+
+        kernel[p.y][p.x] = expf(-static_cast<float>((p.y - kernel_half_size) * (p.y - kernel_half_size) +
+                                                    (p.x - kernel_half_size) * (p.x - kernel_half_size)) /
+                                (2.f * sigma * sigma));
+    }
+}
+
+torch::Tensor
+create_gaussian_kernel(const int kernel_size, const float sigma, const torch::ScalarType& dtype)
+{
+    const auto dtype_result = torch::TensorOptions{}.dtype(dtype).device(torch::kCUDA);
+
+    auto kernel = torch::empty({ kernel_size, kernel_size }, dtype_result);
+
+    at::cuda::CUDAGuard device_guard{ kernel.device() };
+    const auto stream = at::cuda::getCurrentCUDAStream();
+
+    const int threads_per_block = 128;
+    dim3 grid;
+    at::cuda::getApplyGrid(kernel_size * kernel_size, grid, kernel.device().index(), threads_per_block);
+    dim3 threads = at::cuda::getApplyBlock(threads_per_block);
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(kernel.scalar_type(),
+                                        "gaussian_kernel",
+                                        [&]()
+                                        {
+                                            auto kernel_ =
+                                                    kernel.packed_accessor64<scalar_t, 2, torch::RestrictPtrTraits>();
+
+                                            gaussian_kernel<<<grid, threads, 0, stream>>>(kernel_, sigma);
+                                            AT_CUDA_CHECK(cudaGetLastError());
+                                            AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+                                        });
+
+    kernel.div_(kernel.sum(torch::kFloat32).cpu().item<float>());
+
+    return kernel;
+}
+
+torch::Tensor
+gaussian_blur_cuda_dense(const torch::Tensor& images,
+                         const int kernel_size,
+                         const float sigma,
+                         const std::optional<torch::ScalarType> dtype)
+{
+    TORCH_CHECK_GT(kernel_size, 0);
+    TORCH_CHECK_EQ(kernel_size % 2, 1);
+    TORCH_CHECK_GT(sigma, 0.f);
+
+    at::cuda::CUDAGuard device_guard{ images.device() };
+    const auto stream = at::cuda::getCurrentCUDAStream();
+
+    const auto dtype_result = dtype ? *dtype : images.scalar_type();
+
+    if (kernel_size == 1)
+    {
+        return images.clone().to(dtype_result);
+    }
+
+    auto kernel = create_gaussian_kernel(kernel_size, sigma, dtype_result);
+
+    kernel = kernel.unsqueeze(0).unsqueeze(0);
+    kernel = kernel.expand({ 1, images.size(3), kernel_size, kernel_size });
+    kernel = kernel.to(images.device());
+
+    auto images_permuted = images.permute({ 0, 3, 1, 2 }).to(dtype_result);
+    auto padded_images = torch::nn::functional::pad(images_permuted, // B x C x H x W
+                                                    torch::nn::functional::PadFuncOptions{ {
+                                                                                                   kernel_size / 2, // W
+                                                                                                   kernel_size / 2, // W
+                                                                                                   kernel_size / 2, // H
+                                                                                                   kernel_size / 2  // H
+                                                                                           } }
+                                                            .mode(torch::kReflect));
+
+    auto blurred_images_permuted =
+            torch::nn::functional::conv2d(padded_images, kernel, torch::nn::functional::Conv2dFuncOptions{});
+
+    auto blurred_images = blurred_images_permuted.permute({ 0, 2, 3, 1 });
+
+    return blurred_images;
+}
+
+template <typename KernelT>
+__global__ void
+edge_kernel(const torch::PackedTensorAccessor64<KernelT, 4, torch::RestrictPtrTraits> images,
+            torch::PackedTensorAccessor64<uint8_t, 1, torch::RestrictPtrTraits> is_edge)
+{
+    const auto N = is_edge.size(0);
+
+    // Note: image has dims (N, H, W, C) instead of (N, C, H, W)
+    const auto B = images.size(0);
+    const auto H = images.size(1);
+    const auto W = images.size(2);
+
+    const auto image_dims = glm::i64vec3{ W, H, B };
+
+    auto id = static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) + static_cast<int64_t>(threadIdx.x);
+    auto num_threads = static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x);
+    for (auto tid = id; tid < N; tid += num_threads)
+    {
+        auto p = unravel_index(tid, image_dims);
+
+        auto i_00 = images[p.z][p.y][p.x][0];
+        auto i_10 = in_image(p.y, p.x + 1, H, W) ? images[p.z][p.y][p.x + 1][0] : i_00;
+        auto i_01 = in_image(p.y + 1, p.x, H, W) ? images[p.z][p.y + 1][p.x][0] : i_00;
+
+        is_edge[tid] = (i_10 != i_00) || (i_01 != i_00);
+    }
+}
+
+__global__ void
+all_tile_indices_kernel(const int64_t B,
+                        const int64_t H,
+                        const int64_t W,
+                        const int64_t N,
+                        const int tile_size,
+                        const int window_size,
+                        const torch::PackedTensorAccessor64<int64_t, 1, torch::RestrictPtrTraits> edge_indices,
+                        torch::PackedTensorAccessor64<int64_t, 1, torch::RestrictPtrTraits> all_tile_indices)
+{
+    const auto image_dims = glm::i64vec3{ W, H, B };
+    const auto tile_dims = glm::i64vec3{ (W / tile_size) + 1, (H / tile_size) + 1, B };
+
+    auto id = static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) + static_cast<int64_t>(threadIdx.x);
+    auto num_threads = static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x);
+    for (auto tid = id; tid < N; tid += num_threads)
+    {
+        auto p = unravel_index(edge_indices[tid], image_dims);
+
+        const auto window_half_size = window_size / 2;
+        for (int i = -window_half_size; i <= window_half_size; ++i)
+        {
+            for (int j = -window_half_size; j <= window_half_size; ++j)
+            {
+                const auto index = (window_size * window_size) * tid + (i + window_half_size) * window_size +
+                                   (j + window_half_size);
+                all_tile_indices[index] =
+                        ravel_multi_index(glm::i64vec3{ glm::clamp<int64_t>((p.x / tile_size) + i, 0, W / tile_size),
+                                                        glm::clamp<int64_t>((p.y / tile_size) + j, 0, H / tile_size),
+                                                        p.z },
+                                          tile_dims);
+            }
+        }
+    }
+}
+
+template <int kernel_size, typename ImageT, typename BlurredImageT>
+__global__ void
+tile_convolution_kernel_specialized(
+        const torch::PackedTensorAccessor64<int64_t, 1, torch::RestrictPtrTraits> tile_indices,
+        const int64_t N,
+        const int tile_size,
+        const float sigma,
+        const torch::PackedTensorAccessor64<ImageT, 4, torch::RestrictPtrTraits> images,
+        torch::PackedTensorAccessor64<BlurredImageT, 4, torch::RestrictPtrTraits> blurred_images)
+{
+    // Note: image has dims (N, H, W, C) instead of (N, C, H, W)
+    const auto B = images.size(0);
+    const auto H = images.size(1);
+    const auto W = images.size(2);
+
+    const auto image_dims = glm::i64vec3{ W, H, B };
+    const auto tile_dims = glm::i64vec3{ (W / tile_size) + 1, (H / tile_size) + 1, B };
+
+    auto id = static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) + static_cast<int64_t>(threadIdx.x);
+    auto num_threads = static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x);
+    for (auto tid = id; tid < N; tid += num_threads)
+    {
+        auto tile_id = tid / (tile_size * tile_size);
+        auto local_pixel_id = tid % (tile_size * tile_size);
+
+        auto r = unravel_index(tile_indices[tile_id], tile_dims);
+        auto l = glm::i64vec2{ local_pixel_id % tile_size, local_pixel_id / tile_size }; // unravel_index
+
+        auto p = glm::i64vec3{ r.x * tile_size + l.x, r.y * tile_size + l.y, r.z };
+        if (!in_image(p.y, p.x, H, W))
+        {
+            continue;
+        }
+
+        const auto kernel_half_size = kernel_size / 2;
+        auto blurred_val = BlurredImageT{ 0 };
+        auto normalization = BlurredImageT{ 0 };
+        for (auto i = -kernel_half_size; i <= kernel_half_size; ++i)
+        {
+            for (auto j = -kernel_half_size; j <= kernel_half_size; ++j)
+            {
+                auto image_val = static_cast<BlurredImageT>(sample_reflect_padding(images, p.y + j, p.x + i, p.z, 0));
+                auto kernel_val =
+                        static_cast<BlurredImageT>(expf(-static_cast<float>(i * i + j * j) / (2.f * sigma * sigma)));
+
+                blurred_val += kernel_val * image_val;
+                normalization += kernel_val;
+            }
+        }
+
+        blurred_images[p.z][p.y][p.x][0] = blurred_val / normalization;
+    }
+}
+
+template <typename ImageT, typename BlurredImageT>
+__global__ void
+tile_convolution_kernel(const torch::PackedTensorAccessor64<int64_t, 1, torch::RestrictPtrTraits> tile_indices,
+                        const int64_t N,
+                        const int tile_size,
+                        const int kernel_size,
+                        const float sigma,
+                        const torch::PackedTensorAccessor64<ImageT, 4, torch::RestrictPtrTraits> images,
+                        torch::PackedTensorAccessor64<BlurredImageT, 4, torch::RestrictPtrTraits> blurred_images)
+{
+    // Note: image has dims (N, H, W, C) instead of (N, C, H, W)
+    const auto B = images.size(0);
+    const auto H = images.size(1);
+    const auto W = images.size(2);
+
+    const auto image_dims = glm::i64vec3{ W, H, B };
+    const auto tile_dims = glm::i64vec3{ (W / tile_size) + 1, (H / tile_size) + 1, B };
+
+    auto id = static_cast<int64_t>(blockIdx.x) * static_cast<int64_t>(blockDim.x) + static_cast<int64_t>(threadIdx.x);
+    auto num_threads = static_cast<int64_t>(gridDim.x) * static_cast<int64_t>(blockDim.x);
+    for (auto tid = id; tid < N; tid += num_threads)
+    {
+        auto tile_id = tid / (tile_size * tile_size);
+        auto local_pixel_id = tid % (tile_size * tile_size);
+
+        auto r = unravel_index(tile_indices[tile_id], tile_dims);
+        auto l = glm::i64vec2{ local_pixel_id % tile_size, local_pixel_id / tile_size }; // unravel_index
+
+        auto p = glm::i64vec3{ r.x * tile_size + l.x, r.y * tile_size + l.y, r.z };
+        if (!in_image(p.y, p.x, H, W))
+        {
+            continue;
+        }
+
+        const auto kernel_half_size = kernel_size / 2;
+        auto blurred_val = BlurredImageT{ 0 };
+        auto normalization = BlurredImageT{ 0 };
+        for (auto i = -kernel_half_size; i <= kernel_half_size; ++i)
+        {
+            for (auto j = -kernel_half_size; j <= kernel_half_size; ++j)
+            {
+                auto image_val = static_cast<BlurredImageT>(sample_reflect_padding(images, p.y + j, p.x + i, p.z, 0));
+                auto kernel_val =
+                        static_cast<BlurredImageT>(expf(-static_cast<float>(i * i + j * j) / (2.f * sigma * sigma)));
+
+                blurred_val += kernel_val * image_val;
+                normalization += kernel_val;
+            }
+        }
+
+        blurred_images[p.z][p.y][p.x][0] = blurred_val / normalization;
+    }
+}
+
+torch::Tensor
+gaussian_blur_cuda_sparse(const torch::Tensor& images,
+                          const int kernel_size,
+                          const float sigma,
+                          const std::optional<torch::ScalarType> dtype)
+{
+    TORCH_CHECK_GT(kernel_size, 0);
+    TORCH_CHECK_EQ(kernel_size % 2, 1);
+    TORCH_CHECK_GT(sigma, 0.f);
+
+    at::cuda::CUDAGuard device_guard{ images.device() };
+    const auto stream = at::cuda::getCurrentCUDAStream();
+
+    at::cuda::ThrustAllocator allocator;
+    const auto policy = thrust::cuda::par(allocator).on(stream);
+
+    const auto dtype_result = dtype ? *dtype : images.scalar_type();
+    TORCH_CHECK_EQ(torch::isFloatingType(dtype_result), true);
+
+    const auto dtype_uint8 = torch::TensorOptions{}.dtype(torch::kUInt8).device(images.device());
+    const auto dtype_int64 = torch::TensorOptions{}.dtype(torch::kInt64).device(images.device());
+
+    if (kernel_size == 1)
+    {
+        return images.clone().to(dtype_result);
+    }
+
+    // 1. Detect edges
+    const auto N = images.numel();
+    auto is_edge = torch::empty({ N }, dtype_uint8).contiguous();
+
+    const int threads_per_block = 128;
+    dim3 grid_pixels;
+    at::cuda::getApplyGrid(N, grid_pixels, images.device().index(), threads_per_block);
+    dim3 threads = at::cuda::getApplyBlock(threads_per_block);
+
+    AT_DISPATCH_ALL_TYPES_AND(torch::ScalarType::Half,
+                              images.scalar_type(),
+                              "edge_kernel",
+                              [&]()
+                              {
+                                  auto images_ = images.packed_accessor64<scalar_t, 4, torch::RestrictPtrTraits>();
+                                  auto is_edge_ = is_edge.packed_accessor64<uint8_t, 1, torch::RestrictPtrTraits>();
+
+                                  edge_kernel<<<grid_pixels, threads, 0, stream>>>(images_, is_edge_);
+                                  AT_CUDA_CHECK(cudaGetLastError());
+                                  AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+                              });
+
+    // 2. Get indices of edges
+    auto edge_indices = torch::empty({ N }, dtype_int64).contiguous();
+
+    // Flagged is limited to 32-bit indices at least up to cub 2.6
+    TORCH_CHECK_LT(N, (static_cast<int64_t>(1) << 31));
+
+    {
+        void* d_temp_storage = nullptr;
+        size_t temp_storage_bytes = 0;
+        auto num_selected_out = torch::empty({ 1 }, dtype_int64).contiguous();
+
+        AT_CUDA_CHECK(cub::DeviceSelect::Flagged(d_temp_storage,
+                                                 temp_storage_bytes,
+                                                 thrust::counting_iterator<int64_t>(0),
+                                                 is_edge.data_ptr<uint8_t>(),
+                                                 edge_indices.data_ptr<int64_t>(),
+                                                 num_selected_out.data_ptr<int64_t>(),
+                                                 N,
+                                                 stream));
+        AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+        auto temp_storage = torch::empty({ static_cast<int64_t>(temp_storage_bytes) }, dtype_uint8).contiguous();
+
+        AT_CUDA_CHECK(cub::DeviceSelect::Flagged(temp_storage.data_ptr(),
+                                                 temp_storage_bytes,
+                                                 thrust::counting_iterator<int64_t>(0),
+                                                 is_edge.data_ptr<uint8_t>(),
+                                                 edge_indices.data_ptr<int64_t>(),
+                                                 num_selected_out.data_ptr<int64_t>(),
+                                                 N,
+                                                 stream));
+        AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+        edge_indices.resize_({ num_selected_out.cpu().item<int64_t>() });
+    }
+
+    if (edge_indices.numel() == 0)
+    {
+        return images.clone().to(dtype_result);
+    }
+
+    // 3. Compute tiles
+    const auto B = images.size(0);
+    const auto H = images.size(1);
+    const auto W = images.size(2);
+
+    // Whole band should have width of kernel_size, so each tile must be at least 1/2 the size of this
+    const auto tile_size = kernel_size / 2;
+    constexpr auto window_size = 3;
+    auto all_tile_indices =
+            torch::empty({ window_size * window_size * edge_indices.numel() }, dtype_int64).contiguous();
+    auto tile_indices = torch::empty({ window_size * window_size * edge_indices.numel() }, dtype_int64).contiguous();
+
+    dim3 grid_indices;
+    at::cuda::getApplyGrid(edge_indices.numel(), grid_indices, images.device().index(), threads_per_block);
+
+    auto edge_indices_ = edge_indices.packed_accessor64<int64_t, 1, torch::RestrictPtrTraits>();
+    auto all_tile_indices_ = all_tile_indices.packed_accessor64<int64_t, 1, torch::RestrictPtrTraits>();
+
+    all_tile_indices_kernel<<<grid_indices, threads, 0, stream>>>(B,
+                                                                  H,
+                                                                  W,
+                                                                  edge_indices.numel(),
+                                                                  tile_size,
+                                                                  window_size,
+                                                                  edge_indices_,
+                                                                  all_tile_indices_);
+    AT_CUDA_CHECK(cudaGetLastError());
+    AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    thrust::sort(policy,
+                 all_tile_indices.data_ptr<int64_t>(),
+                 all_tile_indices.data_ptr<int64_t>() + all_tile_indices.numel());
+
+    // Unique is limited to 32-bit indices, at least up to cub 2.6
+    TORCH_CHECK_LT(window_size * window_size * edge_indices.numel(), (static_cast<int64_t>(1) << 31));
+
+    {
+        void* d_temp_storage = nullptr;
+        size_t temp_storage_bytes = 0;
+        auto num_selected_out = torch::empty({ 1 }, dtype_int64).contiguous();
+
+        AT_CUDA_CHECK(cub::DeviceSelect::Unique(d_temp_storage,
+                                                temp_storage_bytes,
+                                                all_tile_indices.data_ptr<int64_t>(),
+                                                tile_indices.data_ptr<int64_t>(),
+                                                num_selected_out.data_ptr<int64_t>(),
+                                                all_tile_indices.numel(),
+                                                stream));
+        AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+        auto temp_storage = torch::empty({ static_cast<int64_t>(temp_storage_bytes) }, dtype_uint8).contiguous();
+
+        AT_CUDA_CHECK(cub::DeviceSelect::Unique(temp_storage.data_ptr(),
+                                                temp_storage_bytes,
+                                                all_tile_indices.data_ptr<int64_t>(),
+                                                tile_indices.data_ptr<int64_t>(),
+                                                num_selected_out.data_ptr<int64_t>(),
+                                                all_tile_indices.numel(),
+                                                stream));
+        AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+        tile_indices.resize_({ num_selected_out.cpu().item<int64_t>() });
+    }
+
+    // 4. Convolve pixels in tiles
+    const auto M = tile_indices.numel() * tile_size * tile_size;
+    auto blurred_images = images.clone().to(dtype_result);
+
+    dim3 grid_convolution;
+    at::cuda::getApplyGrid(M, grid_convolution, images.device().index(), threads_per_block);
+
+    AT_DISPATCH_ALL_TYPES_AND(
+            torch::ScalarType::Half,
+            images.scalar_type(),
+            "tile_convolution_kernel",
+            [&]()
+            {
+                auto tile_indices_ = tile_indices.packed_accessor64<int64_t, 1, torch::RestrictPtrTraits>();
+                auto images_ = images.packed_accessor64<scalar_t, 4, torch::RestrictPtrTraits>();
+
+                AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+                        blurred_images.scalar_type(),
+                        "tile_convolution_kernel",
+                        [&]()
+                        {
+                            auto blurred_images_ =
+                                    blurred_images.packed_accessor64<scalar_t, 4, torch::RestrictPtrTraits>();
+
+#define CASE_TILE_CONVOLUTION_KERNEL_SPECIALIZED(KERNEL_SIZE)                                                          \
+    case KERNEL_SIZE:                                                                                                  \
+    {                                                                                                                  \
+        tile_convolution_kernel_specialized<KERNEL_SIZE><<<grid_convolution, threads, 0, stream>>>(tile_indices_,      \
+                                                                                                   M,                  \
+                                                                                                   tile_size,          \
+                                                                                                   sigma,              \
+                                                                                                   images_,            \
+                                                                                                   blurred_images_);   \
+        DEFER(AT_CUDA_CHECK(cudaGetLastError());)                                                                      \
+        DEFER(AT_CUDA_CHECK(cudaStreamSynchronize(stream));)                                                           \
+    }                                                                                                                  \
+    break;
+
+                            switch (kernel_size)
+                            {
+                                // Tested all possible values up to 21 for specialization.
+                                // 7 and 9 are 10% faster, whereas all the others are either equally fast or become
+                                // slightly slower.
+                                CASE_TILE_CONVOLUTION_KERNEL_SPECIALIZED(7)
+                                CASE_TILE_CONVOLUTION_KERNEL_SPECIALIZED(9)
+
+                                default:
+                                {
+                                    tile_convolution_kernel<<<grid_convolution, threads, 0, stream>>>(tile_indices_,
+                                                                                                      M,
+                                                                                                      tile_size,
+                                                                                                      kernel_size,
+                                                                                                      sigma,
+                                                                                                      images_,
+                                                                                                      blurred_images_);
+                                    AT_CUDA_CHECK(cudaGetLastError());
+                                    AT_CUDA_CHECK(cudaStreamSynchronize(stream));
+                                }
+                            }
+                        });
+            });
+
+#undef CASE_TILE_CONVOLUTION_KERNEL_SPECIALIZED
+
+    return blurred_images;
+}
+
+torch::Tensor
+gaussian_blur_cuda(const torch::Tensor& images,
+                   const int kernel_size,
+                   const float sigma,
+                   const bool sparse,
+                   const std::optional<torch::ScalarType> dtype)
+{
+    return sparse ? gaussian_blur_cuda_sparse(images, kernel_size, sigma, dtype)
+                  : gaussian_blur_cuda_dense(images, kernel_size, sigma, dtype);
+}
+
+} // namespace torchhull

--- a/src/torchhull/__init__.py
+++ b/src/torchhull/__init__.py
@@ -48,6 +48,7 @@ charonload.module_config["_c_torchhull"] = charonload.Config(
 
 from _c_torchhull import (
     candidate_voxels_to_wireframes,
+    gaussian_blur,
     marching_cubes,
     sparse_visual_hull_field,
     store_curve_network,
@@ -66,6 +67,7 @@ __copyright__ = f"2024, {__author__}"
 
 __all__ = [
     "candidate_voxels_to_wireframes",
+    "gaussian_blur",
     "marching_cubes",
     "sparse_visual_hull_field",
     "store_curve_network",

--- a/tests/test_gaussian_blur.py
+++ b/tests/test_gaussian_blur.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import functools
+import pathlib
+import sys
+
+import pytest
+import torch
+
+import torchhull
+
+DATA_DIR = pathlib.Path(__file__).parents[1] / "data"
+sys.path.append(str(DATA_DIR))
+from generate_dataset import generate_dataset  # noqa: E402
+
+generate_dataset = functools.cache(generate_dataset)
+
+
+DEVICE = torch.device("cuda")
+
+
+@pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.parametrize(
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
+)
+@pytest.mark.parametrize("dtype_blurred", [torch.float16, torch.float32, torch.float64])
+def test_gaussian_blur_empty_masks(
+    sparse: bool,
+    dtype_masks: torch.dtype,
+    dtype_blurred: torch.dtype,
+) -> None:
+    data_dir = pathlib.Path(__file__).parents[1] / "data"
+    file = "Armadillo.ply"
+
+    _, _, masks_reference = generate_dataset(mesh_file=data_dir / file, device=DEVICE)
+
+    masks_reference = masks_reference.to(dtype=dtype_masks, device=DEVICE)
+    masks = torch.zeros_like(masks_reference)
+
+    kernel_size = 5
+    sigma = 1
+
+    blurred_masks = torchhull.gaussian_blur(
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=sparse,
+        dtype=dtype_blurred,
+    )
+
+    assert blurred_masks.dtype == dtype_blurred
+    assert torch.allclose(blurred_masks, masks.to(dtype_blurred))
+
+
+@pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.parametrize(
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
+)
+@pytest.mark.parametrize("dtype_blurred", [torch.float16, torch.float32, torch.float64])
+def test_gaussian_blur_full_masks(
+    sparse: bool,
+    dtype_masks: torch.dtype,
+    dtype_blurred: torch.dtype,
+) -> None:
+    data_dir = pathlib.Path(__file__).parents[1] / "data"
+    file = "Armadillo.ply"
+
+    _, _, masks_reference = generate_dataset(mesh_file=data_dir / file, device=DEVICE)
+
+    masks_reference = masks_reference.to(dtype=dtype_masks, device=DEVICE)
+    masks = torch.ones_like(masks_reference)
+
+    kernel_size = 5
+    sigma = 1
+
+    blurred_masks = torchhull.gaussian_blur(
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=sparse,
+        dtype=dtype_blurred,
+    )
+
+    assert blurred_masks.dtype == dtype_blurred
+    assert torch.allclose(blurred_masks, masks.to(dtype_blurred))
+
+
+@pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.parametrize(
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
+)
+@pytest.mark.parametrize("dtype_blurred", [torch.float16, torch.float32, torch.float64])
+def test_gaussian_blur_kernel_size_1(
+    sparse: bool,
+    dtype_masks: torch.dtype,
+    dtype_blurred: torch.dtype,
+) -> None:
+    data_dir = pathlib.Path(__file__).parents[1] / "data"
+    file = "Armadillo.ply"
+
+    _, _, masks = generate_dataset(mesh_file=data_dir / file, device=DEVICE)
+
+    masks = masks.to(dtype=dtype_masks, device=DEVICE)
+
+    kernel_size = 1
+    sigma = 1
+
+    blurred_masks = torchhull.gaussian_blur(
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=sparse,
+        dtype=dtype_blurred,
+    )
+
+    assert blurred_masks.dtype == dtype_blurred
+    assert torch.allclose(blurred_masks, masks.to(dtype_blurred))
+
+
+@pytest.mark.parametrize("kernel_size", [3, 5, 7, 9, 11])
+@pytest.mark.parametrize("sigma", [1.0, 100.0])
+@pytest.mark.parametrize("masks_partial", [True, False])
+@pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.parametrize("dtype_masks", [torch.float16, torch.float32, torch.float64])
+def test_gaussian_blur_default_type(
+    kernel_size: int,
+    sigma: float,
+    masks_partial: bool,
+    sparse: bool,
+    dtype_masks: torch.dtype,
+) -> None:
+    data_dir = pathlib.Path(__file__).parents[1] / "data"
+    file = "Armadillo.ply"
+
+    _, _, masks = generate_dataset(mesh_file=data_dir / file, device=DEVICE)
+
+    masks = masks.to(dtype=dtype_masks, device=DEVICE)
+
+    crop_x = 700
+    crop_y = 400
+    masks = masks[:, crop_y:-crop_y, crop_x:-crop_x, :].clone() if masks_partial else masks
+
+    blurred_masks = torchhull.gaussian_blur(
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=sparse,
+    )
+
+    assert blurred_masks.dtype == masks.dtype
+    assert torch.all(blurred_masks >= 0.0 - 1e-5)
+    assert torch.all(blurred_masks <= 1.0 + 1e-5)
+
+
+@pytest.mark.parametrize("kernel_size", [3, 5, 7, 9, 11])
+@pytest.mark.parametrize("sigma", [1.0, 100.0])
+@pytest.mark.parametrize("masks_partial", [True, False])
+@pytest.mark.parametrize("sparse", [True, False])
+@pytest.mark.parametrize(
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
+)
+@pytest.mark.parametrize("dtype_blurred", [torch.float16, torch.float32, torch.float64])
+def test_gaussian_blur(
+    kernel_size: int,
+    sigma: float,
+    masks_partial: bool,
+    sparse: bool,
+    dtype_masks: torch.dtype,
+    dtype_blurred: torch.dtype,
+) -> None:
+    data_dir = pathlib.Path(__file__).parents[1] / "data"
+    file = "Armadillo.ply"
+
+    _, _, masks = generate_dataset(mesh_file=data_dir / file, device=DEVICE)
+
+    masks = masks.to(dtype=dtype_masks, device=DEVICE)
+
+    crop_x = 700
+    crop_y = 400
+    masks = masks[:, crop_y:-crop_y, crop_x:-crop_x, :].clone() if masks_partial else masks
+
+    blurred_masks = torchhull.gaussian_blur(
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=sparse,
+        dtype=dtype_blurred,
+    )
+
+    assert blurred_masks.dtype == dtype_blurred
+    assert torch.all(blurred_masks >= 0.0 - 1e-5)
+    assert torch.all(blurred_masks <= 1.0 + 1e-5)
+
+
+@pytest.mark.parametrize("kernel_size", [3, 5, 7, 9, 11])
+@pytest.mark.parametrize("sigma", [1.0, 100.0])
+@pytest.mark.parametrize("masks_partial", [True, False])
+@pytest.mark.parametrize(
+    "dtype_masks", [torch.int8, torch.int16, torch.int32, torch.int64, torch.float16, torch.float32, torch.float64]
+)
+@pytest.mark.parametrize("dtype_blurred", [torch.float16, torch.float32, torch.float64])
+def test_gaussian_blur_consistent(
+    kernel_size: int,
+    sigma: float,
+    masks_partial: bool,
+    dtype_masks: torch.dtype,
+    dtype_blurred: torch.dtype,
+) -> None:
+    data_dir = pathlib.Path(__file__).parents[1] / "data"
+    file = "Armadillo.ply"
+
+    _, _, masks = generate_dataset(mesh_file=data_dir / file, device=DEVICE)
+
+    masks = masks.to(dtype=dtype_masks, device=DEVICE)
+
+    crop_x = 700
+    crop_y = 400
+    masks = masks[:, crop_y:-crop_y, crop_x:-crop_x, :].clone() if masks_partial else masks
+
+    blurred_masks_dense = torchhull.gaussian_blur(
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=False,
+        dtype=dtype_blurred,
+    )
+
+    blurred_masks_sparse = torchhull.gaussian_blur(
+        images=masks,
+        kernel_size=kernel_size,
+        sigma=sigma,
+        sparse=True,
+        dtype=dtype_blurred,
+    )
+
+    if dtype_blurred == torch.float16:
+        epsilon = 3e-3
+    if dtype_blurred == torch.float32:
+        epsilon = 1e-7
+    if dtype_blurred == torch.float64:
+        epsilon = 1e-7
+
+    assert torch.allclose(blurred_masks_dense, blurred_masks_sparse, atol=epsilon)


### PR DESCRIPTION
The visual hull of binary masks usually has a block-like shape even at high voxel resolutions due to the hard (binary) edges. Add Gaussian blur as a preprocessing step to compute smoother masks. In addition to standard version performing a full convolution of the images, this includes a faster sparse version which only performs convolution in images tiles around the silhouette edges and avoids expensive computation in constant regions.