### PR TITLE
Add missing docs for Gaussian blur

### DIFF
--- a/docs/src/api/torchhull.rst
+++ b/docs/src/api/torchhull.rst
@@ -10,6 +10,7 @@
     :hidden:
 
     torchhull/candidate_voxels_to_wireframes
+    torchhull/gaussian_blur
     torchhull/marching_cubes
     torchhull/sparse_visual_hull_field
     torchhull/store_curve_network

--- a/docs/src/api/torchhull/gaussian_blur.rst
+++ b/docs/src/api/torchhull/gaussian_blur.rst
@@ -1,0 +1,6 @@
+gaussian_blur
+=============
+
+.. currentmodule:: torchhull
+
+.. autofunction:: gaussian_blur


### PR DESCRIPTION
In #14, Gaussian blurring was introduced. Although the corresponding docstring is present, it is not used in the generation of the documentation. Add the missing docs.