### PR TITLE
Fix pixel rounding in revised partial mask condition

### DIFF
--- a/src/torchhull/_C/src/visual_hull_cuda.cu
+++ b/src/torchhull/_C/src/visual_hull_cuda.cu
@@ -355,7 +355,8 @@ classify_children_partial(const torch::PackedTensorAccessor64<int64_t, 1, torch:
                 bb_max.x = fmaxf(bb_max.x, v_pixel.x);
                 bb_max.y = fmaxf(bb_max.y, v_pixel.y);
 
-                if (!in_image(v_pixel.y, v_pixel.x, H, W, 1))
+                auto v_pixel_rounded = glm::i64vec2{ roundf(v_pixel.x), roundf(v_pixel.y) };
+                if (!in_image(v_pixel_rounded.y, v_pixel_rounded.x, H, W, 1))
                 {
                     fully_inside = false;
                 }


### PR DESCRIPTION
In #18, the partial mask condition has been revised. However, the check whether the pixel lies within the image just implicitly converts to int64_t instead of doing proper rounding beforehand. Fix this issue to make it consistent with the accumulation part which performs correctly.