### PR TITLE
Move conversion from ravelled to sparse tensor to dedicated function

### DIFF
--- a/src/torchhull/_C/include/torchhull/ravelled_sparse_tensor.h
+++ b/src/torchhull/_C/include/torchhull/ravelled_sparse_tensor.h
@@ -66,6 +66,12 @@ public:
         return sizes_[i];
     }
 
+    inline std::vector<int64_t>
+    sizes() const
+    {
+        return sizes_;
+    }
+
     inline torch::ScalarType
     scalar_type() const
     {


### PR DESCRIPTION
The conversion from the internal ravelled tensor representation to a proper sparse COO tensor is currently inlined. This function is useful on its own, so extract it and move it to a dedicated (yet still internal) function. While at it, also clean up the accumulate kernels to expect the grid resolution rather than the cell resolution since the input is actually ravelled via the former one.